### PR TITLE
Updated Ubuntu to Vivid, Chef to 11.10, added apt dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "cookbooks/apt"]
+	path = cookbooks/apt
+	url = https://github.com/opscode-cookbooks/apt
 [submodule "cookbooks/java"]
 	path = cookbooks/java
 	url = https://github.com/opscode-cookbooks/java.git

--- a/VagrantFile
+++ b/VagrantFile
@@ -2,11 +2,11 @@
 # vi: set ft=ruby :
  
 Vagrant::Config.run do |config|
-  config.vm.box = "lucid64"
-  config.vm.box_url = "http://files.vagrantup.com/lucid64.box"
+  config.vm.box = "ubuntu/vivid64"
+  # config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
   
   # Upgrade Chef for ark to work
-  config.vm.provision :shell, :inline => "gem install chef --version 11.4.2 --no-rdoc --no-ri --conservative"
+  config.vm.provision :shell, :inline => "apt-get install -y ruby ruby-dev; gem install chef --version 11.10 --no-rdoc --no-ri --conservative"
 
   # Refresh package list
   config.vm.provision :shell, :inline => "apt-get update"


### PR DESCRIPTION
The current cookbook doesn't work anymore (dependencies break on vagrant up). This setup works for me, so I figured I'd push it over. I'm also going to do a pull request for a set of "mule-cookbook" that bring it more in line with current version.